### PR TITLE
WORK-C batch 4: Discover & Detail UX polish (4 fixes)

### DIFF
--- a/app/recipes/routes.py
+++ b/app/recipes/routes.py
@@ -64,10 +64,26 @@ def discover():
         .all()
     )
 
+    # Build the category pill list from what's actually in the DB so any
+    # category that appears on a recipe card also has a matching filter pill.
+    # Use CATEGORY_CHOICES labels where available, otherwise title-case the
+    # raw value as a fallback (e.g. "indian" -> "Indian").
+    label_map = dict(CATEGORY_CHOICES)
+    db_categories = (
+        db.session.query(Recipe.category)
+        .filter(Recipe.is_public.is_(True), Recipe.is_deleted.is_(False), Recipe.category.isnot(None))
+        .distinct()
+        .all()
+    )
+    categories = sorted(
+        [(value, label_map.get(value, value.replace('-', ' ').title())) for (value,) in db_categories],
+        key=lambda pair: pair[1],
+    )
+
     return render_template(
         'recipes/discover.html',
         recipes=recipes,
-        categories=CATEGORY_CHOICES,
+        categories=categories,
         total=total,
         page=page,
         per_page=per_page,

--- a/app/recipes/routes.py
+++ b/app/recipes/routes.py
@@ -216,6 +216,13 @@ def detail(slug):
     comments = recipe.comments.all()
     ingredients = recipe.ingredients.all()
 
+    # Build a 1..5 -> count distribution so the template can render bars.
+    # We use .all() because recipe.ratings is a query, not a list.
+    rating_distribution = {i: 0 for i in range(1, 6)}
+    for r in recipe.ratings.all():
+        if r.score in rating_distribution:
+            rating_distribution[r.score] += 1
+
     user_saved = False
     user_rating = 0
     if current_user.is_authenticated:
@@ -233,6 +240,7 @@ def detail(slug):
         recipe=recipe,
         avg_rating=avg_rating,
         rating_count=rating_count,
+        rating_distribution=rating_distribution,
         comments=comments,
         ingredients=ingredients,
         user_saved=user_saved,

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -4005,3 +4005,14 @@ html {
   0%   { background: rgba(110, 231, 183, 0.35); }
   100% { background: transparent; }
 }
+
+/* ── D4: neutralise browser default <button> styles for .tag pills ── */
+button.tag {
+  font-family: inherit;
+  line-height: 1.2;
+  cursor: pointer;
+}
+button.tag:focus-visible {
+  outline: 2px solid var(--pt-mint, #6ee7b7);
+  outline-offset: 2px;
+}

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -4016,3 +4016,42 @@ button.tag:focus-visible {
   outline: 2px solid var(--pt-mint, #6ee7b7);
   outline-offset: 2px;
 }
+
+/* ── C3: rating distribution breakdown bars on recipe detail ── */
+.rating-breakdown {
+  max-width: 360px;
+  margin-top: 0.5rem;
+}
+.rating-breakdown-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.3rem;
+  font-size: 0.82rem;
+}
+.rating-breakdown-label {
+  min-width: 38px;          /* keeps "5 star" / "1 star" rows aligned */
+  color: var(--pt-sun);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+.rating-breakdown-bar {
+  flex: 1;
+  height: 8px;
+  background: var(--pt-surface2, rgba(255, 255, 255, 0.08));
+  border-radius: 4px;
+  overflow: hidden;
+}
+.rating-breakdown-fill {
+  height: 100%;
+  background: var(--pt-sun, #ffd93d);
+  transition: width 0.3s ease;
+}
+.rating-breakdown-count {
+  min-width: 28px;          /* keeps counts aligned regardless of digit count */
+  text-align: right;
+  color: var(--pt-muted);
+  font-variant-numeric: tabular-nums;
+}

--- a/app/static/js/discover.js
+++ b/app/static/js/discover.js
@@ -24,18 +24,25 @@
 
     /* ── Tag pills ── */
 
+    function setActiveTag(activePill) {
+        tagPills.forEach(t => {
+            const isActive = t === activePill;
+            t.classList.toggle('active', isActive);
+            t.setAttribute('aria-pressed', String(isActive));
+        });
+    }
+
     tagPills.forEach(pill => {
         pill.addEventListener('click', () => {
             const category = pill.dataset.category;
 
             if (pill.classList.contains('active') && category !== '') {
-                pill.classList.remove('active');
-                currentCategory = '';
+                // Deselecting the current category — fall back to "All".
                 const allPill = document.querySelector('#category-tags .tag[data-category=""]');
-                if (allPill) allPill.classList.add('active');
+                setActiveTag(allPill || pill);
+                currentCategory = '';
             } else {
-                tagPills.forEach(t => t.classList.remove('active'));
-                pill.classList.add('active');
+                setActiveTag(pill);
                 currentCategory = category || '';
             }
 

--- a/app/static/js/discover.js
+++ b/app/static/js/discover.js
@@ -17,9 +17,15 @@
     const initialPage = parseInt(resultsContainer.dataset.currentPage, 10) || 1;
     const perPage = parseInt(resultsContainer.dataset.perPage, 10) || 12;
 
+    // Pick up initial filter state from the URL so deep links like
+    // /discover?category=vegan or /discover?q=pasta apply on page load.
+    const urlParams = new URLSearchParams(window.location.search);
+    const initialCategory = (urlParams.get('category') || '').toLowerCase();
+    const initialQuery = urlParams.get('q') || '';
+
     let currentPage = initialPage;
-    let currentQuery = '';
-    let currentCategory = '';
+    let currentQuery = initialQuery;
+    let currentCategory = initialCategory;
     let currentSort = 'newest';
 
     /* ── Tag pills ── */
@@ -181,5 +187,22 @@
         const div = document.createElement('div');
         div.appendChild(document.createTextNode(str));
         return div.innerHTML;
+    }
+
+    /* ── Initial sync: apply ?category and ?q from URL on page load ── */
+    if (initialCategory || initialQuery) {
+        if (searchInput && initialQuery) {
+            searchInput.value = initialQuery;
+        }
+        if (initialCategory) {
+            tagPills.forEach(t => {
+                const isMatch = t.dataset.category.toLowerCase() === initialCategory;
+                t.classList.toggle('active', isMatch);
+                t.setAttribute('aria-pressed', String(isMatch));
+            });
+        }
+        // Re-fetch from page 1 with the URL-derived filters applied.
+        currentPage = 1;
+        fetchRecipes(false);
     }
 })();

--- a/app/templates/partials/_recipe_card.html
+++ b/app/templates/partials/_recipe_card.html
@@ -7,7 +7,11 @@
     <h3><a href="/recipe/{{ recipe.slug }}" class="text-decoration-none" style="color: var(--pt-text);">{{ recipe.title }}</a></h3>
     <p>
         <i class="bi bi-clock"></i> {{ recipe.cooking_time or 30 }} min
-        <span class="badge bg-info ms-2">{{ recipe.category|capitalize }}</span>
+        {% if recipe.category %}
+        <a href="{{ url_for('recipes.discover') }}?category={{ recipe.category|lower }}"
+           class="badge bg-info ms-2 text-decoration-none"
+           title="Filter by {{ recipe.category|capitalize }}">{{ recipe.category|capitalize }}</a>
+        {% endif %}
         {% if recipe.is_ai_generated %}
         <span class="badge badge-ai ms-1">AI</span>
         {% endif %}

--- a/app/templates/recipes/detail.html
+++ b/app/templates/recipes/detail.html
@@ -28,7 +28,11 @@
             <span class="text-muted-custom">
                 <i class="bi bi-clock me-1"></i>{{ recipe.cooking_time or 30 }} min
             </span>
-            <span class="badge bg-info">{{ recipe.category|capitalize }}</span>
+            {% if recipe.category %}
+            <a href="{{ url_for('recipes.discover') }}?category={{ recipe.category|lower }}"
+               class="badge bg-info text-decoration-none"
+               title="Filter by {{ recipe.category|capitalize }}">{{ recipe.category|capitalize }}</a>
+            {% endif %}
             {% if recipe.creator %}
             <span class="text-muted-custom small">
                 <i class="bi bi-journal-text"></i> {{ recipe.creator.recipes.count() }} recipes

--- a/app/templates/recipes/detail.html
+++ b/app/templates/recipes/detail.html
@@ -133,6 +133,22 @@
         <span class="badge bg-success">You rated {{ user_rating }}/5</span>
         {% endif %}
     </div>
+
+    {% if rating_count > 0 %}
+    <div class="rating-breakdown" aria-label="Rating distribution">
+        {% for score in [5, 4, 3, 2, 1] %}
+        {% set count = rating_distribution[score] %}
+        {% set pct = (count / rating_count * 100) if rating_count else 0 %}
+        <div class="rating-breakdown-row">
+            <span class="rating-breakdown-label">{{ score }} <i class="bi bi-star-fill" aria-hidden="true"></i></span>
+            <div class="rating-breakdown-bar">
+                <div class="rating-breakdown-fill" style="width: {{ pct }}%;"></div>
+            </div>
+            <span class="rating-breakdown-count">{{ count }}</span>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 </section>
 
 <!-- Comments Section -->

--- a/app/templates/recipes/discover.html
+++ b/app/templates/recipes/discover.html
@@ -13,10 +13,10 @@
     </div>
 
     <!-- Category Pills -->
-    <div class="discover-tags mb-3" id="category-tags">
-        <span class="tag active" data-category="">All</span>
+    <div class="discover-tags mb-3" id="category-tags" role="group" aria-label="Filter by category">
+        <button type="button" class="tag active" data-category="" aria-pressed="true">All</button>
         {% for value, label in categories %}
-        <span class="tag" data-category="{{ value }}">{{ label }}</span>
+        <button type="button" class="tag" data-category="{{ value }}" aria-pressed="false">{{ label }}</button>
         {% endfor %}
     </div>
 


### PR DESCRIPTION
## Summary

This PR addresses **4 items from the WORK-C audit doc** (`audit_docs/WORK-C-recipes-discover.md`), all themed around polishing the Discover-page and recipe-detail UX. Includes accessibility, deep-linking, and a new visual element (rating distribution).

## Changes

### Discover page filtering
- **D4** — `discover.html`, `discover.js`, `style.css`: category pills are now real `<button type="button">` elements with `aria-pressed` toggling in lockstep with `.active`. Container has `role="group"` + `aria-label`. JS refactored to use a `setActiveTag()` helper so class + ARIA can never drift. Added `:focus-visible` outline + `font-family: inherit` reset to neutralise browser default `<button>` styles.
- **C-V10** — `recipes/routes.py` `discover()`: category pills are now built from `db.session.query(Recipe.category).distinct()` filtered to public, non-deleted recipes — instead of the hardcoded `CATEGORY_CHOICES`. Pulls labels from `CATEGORY_CHOICES` where available, falls back to title-cased raw value (e.g. `"middle-eastern"` → `"Middle Eastern"`). Sorted alphabetically.

### Clickable category badges
- **C4 + U9** — `_recipe_card.html`, `detail.html`: replaced static `<span class="badge">` with `<a href="/discover?category=...">` so badges deep-link to a filtered Discover page.
- **C4 + U9 (cont.)** — `discover.js`: now reads `?category=` and `?q=` from the URL on page load via `URLSearchParams`, syncs the matching pill's active/aria-pressed state and the search input value, then triggers a fetch so the deep link actually filters.

### Rating UX (recipe detail page)
- **C3** — `recipes/routes.py` `detail()` + `detail.html` + `style.css`: added a 1-5 star distribution breakdown below the average rating. Backend builds a `{score: count}` dict; template renders 5-star-at-top bars sized as `count / rating_count * 100`%; whole block hidden when there are zero ratings. CSS uses `min-width` + `font-variant-numeric: tabular-nums` for clean alignment.

### Confirmation (no code change)
- **C-V12** — Discover Load More button hides when there are no more results. This was already implemented as part of B5 in the previous PR (`loadMoreWrap.innerHTML = data.has_next ? '...' : ''`). Listed here for audit traceability.

## Testing

- Booted locally (`flask run`), manually verified each fix in the browser.
- Tabbed into the Discover pills, confirmed mint focus outline + Enter activates the filter.
- Confirmed `/discover?category=vegan` deep-link lands with the Vegan pill active and only vegan recipes shown.
- Confirmed clicking a badge on a recipe card navigates to a filtered Discover page.
- Confirmed rating breakdown shows on a recipe with multiple ratings; confirmed it's hidden on a recipe with zero ratings.
- Confirmed the C-V10 pill list now reflects the DB (no "ghost" categories).

## Notes for reviewers

- **No DB migrations.** No new dependencies.
- The deep-link filter (C4 + U9) causes a brief flash of unfiltered recipes on page load before the JS fetch returns the filtered set. Fixing this would require duplicating filter logic into the route's initial render — out of scope for this PR.
- C-V10's category sort is alphabetical by *label*, not by raw value — so "High Protein" sorts under "H" not "h" or "high-protein".
- Community feed (`feed.html`) also has a category badge that could become clickable, but that file is in WORK-D scope so I left it untouched.

## Audit IDs covered

D4, C-V10, C4, U9, C3 (+ C-V12 confirmed via B5)