### PR TITLE
fix: wire Add to Meal Plan button to modal and add grocery print styles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1591,6 +1591,10 @@ footer p {
     display: none !important;
   }
 
+  .grocery-list {
+    font-size: 14pt;
+  }
+
   .card,
   .pt-card,
   .panel,

--- a/app/templates/recipes/detail.html
+++ b/app/templates/recipes/detail.html
@@ -54,9 +54,10 @@
             </button>
             {% endif %}
         {% endif %}
-        <a href="/planner" class="btn btn-sm btn-outline-light">
+        <button type="button" class="btn btn-sm btn-outline-light"
+                onclick="openAddToPlanModal({{ recipe.id }}, {{ recipe.title|tojson }})">
             <i class="bi bi-calendar-plus me-1"></i> Add to Meal Plan
-        </a>
+        </button>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Replaced `<a href="/planner">` with a button that opens the `openAddToPlanModal` on recipe detail page
- Added `.grocery-list { font-size: 14pt }` to print stylesheet