### PR TITLE
chore: restore .gitignore (was blanked during merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+venv/
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+pytest-cache-files-*/
+instance/
+*.db
+.env
+.DS_Store
+app/static/uploads/*
+!app/static/uploads/.gitkeep


### PR DESCRIPTION
The `.gitignore` on main is currently 0 bytes, looks like a previous merge resolution dropped its contents.

This PR restores the standard entries:

- `venv/` / `.venv/` — virtual environments
- `__pycache__/` / `*.pyc` — Python bytecode caches
- `.pytest_cache/` / `pytest-cache-files-*/` — pytest temp dirs
- `instance/` — Flask instance folder (local sqlite DB)
- `*.db` — any sqlite files
- `.env` — local secrets
- `.DS_Store` — macOS junk
- `app/static/uploads/*` — user-uploaded recipe images
- (with `!app/static/uploads/.gitkeep` to keep the folder placeholder)

After this merges, `git status` will be clean for everyone.

No code changes.