### PR TITLE
fix: remove selectinload on dynamic relationship to fix pantry AI 500

### DIFF
--- a/app/ai/services.py
+++ b/app/ai/services.py
@@ -1,8 +1,6 @@
 import json
 
 from flask import current_app
-from sqlalchemy.orm import selectinload
-
 from app import db
 from app.models import Recipe, PantryItem
 from app.ai.recipe_defaults import (
@@ -27,7 +25,7 @@ def get_pantry_matches(user_id, max_time=None):
 
     query = Recipe.query.filter_by(
         is_public=True, is_deleted=False
-    ).options(selectinload(Recipe.ingredients))
+    )
 
     if max_time:
         query = query.filter(Recipe.cooking_time <= int(max_time))


### PR DESCRIPTION
## Summary
- `/api/ai/suggest` was returning 500 because `selectinload(Recipe.ingredients)` was applied to a `lazy='dynamic'` relationship, which SQLAlchemy does not support. Removed the eager load.

## Test plan
- [ ] Log in → Pantry AI → add ingredients → Find Matching Recipes returns results (no 500)