### PR TITLE
fix: community feed image fallback 

### DIFF
--- a/app/templates/community/feed.html
+++ b/app/templates/community/feed.html
@@ -53,7 +53,11 @@
                         <div class="pt-card mt-2">
                             <div class="img-ph">
                                 {% if recipe.image_filename %}
-                                <img src="{{ url_for('static', filename='uploads/' + recipe.image_filename) }}"
+                                <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
+                                     alt="{{ recipe.title }}"
+                                     style="width:100%;height:100%;object-fit:cover;border-radius:inherit">
+                                {% else %}
+                                <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
                                      alt="{{ recipe.title }}"
                                      style="width:100%;height:100%;object-fit:cover;border-radius:inherit">
                                 {% endif %}


### PR DESCRIPTION
Same image-fallback pattern I applied to `_recipe_card.html`, `_my_meal_card.html`, `detail.html`, and the auth profile templates — now applied to `community/feed.html` so the community page also gets:

1. **URL/filename autodetect** for `recipe.image_filename` (curated Wikimedia URLs from `seed.py` were rendering as broken `<img src="/static/uploads/https://...">`)
2. **Loremflickr fallback** when there's no `image_filename` (was rendering an empty `.img-ph` placeholder div)


No backend / DB changes. One template, two-line conditional change.