### PR TITLE
security: require SECRET_KEY env var, drop hardcoded fallback

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,13 @@ def create_app(config_class=Config):
     app = Flask(__name__)
     app.config.from_object(config_class)
 
+    # Fail fast if SECRET_KEY isn't set — never run with a placeholder secret.
+    if not app.config.get('SECRET_KEY'):
+        raise RuntimeError(
+            "SECRET_KEY environment variable must be set. "
+            "Copy .env.example to .env and fill in SECRET_KEY (any random string)."
+        )
+
     db.init_app(app)
     login_manager.init_app(app)
     migrate.init_app(app, db)

--- a/config.py
+++ b/config.py
@@ -6,7 +6,10 @@ load_dotenv(os.path.join(basedir, '.env'))
 
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'fallback-dev-key'
+    # SECRET_KEY MUST come from the environment. No hardcoded fallback so that
+    # missing config fails loudly at startup rather than silently using a
+    # well-known dev key in production. Validated in app/__init__.py create_app.
+    SECRET_KEY = os.environ.get('SECRET_KEY')
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'instance', 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -17,6 +20,9 @@ class Config:
 
 class TestConfig(Config):
     TESTING = True
+    # Tests don't need a real secret — explicit value so the production
+    # validation in create_app doesn't trip when running pytest.
+    SECRET_KEY = 'test-secret-key-not-for-production'
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
     WTF_CSRF_ENABLED = False
     SERVER_NAME = 'localhost.localdomain'


### PR DESCRIPTION
Previous code in `config.py`:

```python
SECRET_KEY = os.environ.get('SECRET_KEY') or 'fallback-dev-key'
```

The `or 'fallback-dev-key'` IS a hardcoded secret in source code, even though there's an env var check first. This PR removes the fallback and validates that the env var is set at app startup.

### Changes

- **`config.py`**:
  - `Config.SECRET_KEY` now reads only from env var (no `or 'fallback-...'`)
  - `TestConfig.SECRET_KEY` set explicitly to a fixed test value so pytest still works
- **`app/__init__.py create_app()`**:
  - After `app.config.from_object(...)`, raises a clear `RuntimeError` if `SECRET_KEY` is missing, pointing at `.env` for the fix

### Teammate setup

`.env.example` already has the placeholder line:
SECRET_KEY=change-me-to-a-random-string

Anyone whose local `.env` doesn't have `SECRET_KEY` set will hit the new error and need to add it. Almost everyone should already have it from following the README setup.

### Scope

`config.py` is technically Person A's WORK-A scope, coordinated with him on chat first; he's happy for me to ship this.