### PR TITLE
fix(auth): WORK-B polish — login/register theme, profile edit bugs, user search 500, image fallback, validators

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -3,6 +3,7 @@ from flask_wtf.file import FileField, FileAllowed
 from wtforms import StringField, PasswordField, BooleanField, TextAreaField, SubmitField
 from wtforms.validators import DataRequired, Email, EqualTo, Length, ValidationError, Optional, Regexp
 
+from flask_login import current_user
 from sqlalchemy import func
 
 from app.models import User
@@ -58,10 +59,25 @@ class EditProfileForm(FlaskForm):
     image = FileField('Profile Picture', validators=[Optional(), FileAllowed(['jpg', 'jpeg', 'png', 'gif', 'webp'])])
     submit = SubmitField('Save Changes')
     def validate_new_username(self, field):
-        if User.query.filter_by(username=field.data).first():
+        # Skip if user left the field blank (Optional() means no change requested).
+        value = (field.data or '').strip().lower()
+        if not value:
+            return
+        existing = User.query.filter(
+            func.lower(User.username) == value,
+            User.id != current_user.id,    # exclude self — re-submitting own name is fine
+        ).first()
+        if existing:
             raise ValidationError('already taken.')
 
     def validate_new_email(self, field):
-        if User.query.filter_by(email=field.data).first():
+        value = (field.data or '').strip().lower()
+        if not value:
+            return
+        existing = User.query.filter(
+            func.lower(User.email) == value,
+            User.id != current_user.id,
+        ).first()
+        if existing:
             raise ValidationError('already registered.')
         

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -235,11 +235,10 @@ def users():
 @bp.route('/api/users')
 def api_users():
     q = request.args.get('q', '', type=str).strip()
-    page = request.args.get('page', 1, type=int)
-    per_page = request.args.get('per_page', 12, type=int)
+    page = max(request.args.get('page', 1, type=int), 1)
+    per_page = max(1, min(request.args.get('per_page', 12, type=int), 50))
 
     query = User.query
-
     if q:
         query = query.filter(User.username.ilike(f'%{q}%'))
 
@@ -247,4 +246,13 @@ def api_users():
     users = query.offset((page - 1) * per_page).limit(per_page).all()
     has_next = (page * per_page) < total
 
-    return jsonify(users=users, total=total, has_next=has_next)
+    # SQLAlchemy User objects aren't JSON-serialisable directly — convert to dicts.
+    return jsonify(
+        users=[{
+            'id': u.id,
+            'username': u.username,
+            'avatar_url': u.avatar_url,
+        } for u in users],
+        total=total,
+        has_next=has_next,
+    )

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-12" style="max-width: 420px;">
-    <div class="card bg-dark border-secondary shadow">
+    <div class="card pt-panel shadow">
       <div class="card-body p-4">
         <h2 class="card-title text-center mb-4">
           <i class="bi bi-box-arrow-in-right"></i> Sign In
@@ -16,7 +16,7 @@
 
           <div class="mb-3">
             {{ form.username.label(class="form-label") }}
-            {{ form.username(class="form-control text-light", placeholder="Your username") }}
+            {{ form.username(class="form-control", placeholder="Your username") }}
             {% for error in form.username.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}
@@ -24,7 +24,7 @@
 
           <div class="mb-3">
             {{ form.password.label(class="form-label") }}
-            {{ form.password(class="form-control text-light", placeholder="Password") }}
+            {{ form.password(class="form-control", placeholder="Password") }}
             {% for error in form.password.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}

--- a/app/templates/auth/profile.html
+++ b/app/templates/auth/profile.html
@@ -276,42 +276,31 @@
 
                 <label for="new_username" class="form-label" style="color: var(--pt-text-secondary);">Change Username</label>
                 <input class="form-control" id="new_username" name="new_username"
-                          placeholder=""></input>
-                {% for field, error in edit_form.errors.items() %}
-                  {% if field == new_username %}
-                    <div class="text-danger small mt-1">{{ error }}</div>
-                  {% endif %}
+                       placeholder="" value="{{ edit_form.new_username.data or '' }}">
+                {% for error in edit_form.new_username.errors %}
+                  <div class="text-danger small mt-1">{{ error }}</div>
                 {% endfor %}
 
                 <label for="new_email" class="form-label" style="color: var(--pt-text-secondary);">Change Email</label>
-                <input class="form-control" id="new_email" name="new_email" rows="1"
-                          placeholder="">{{ edit_form.new_email.data or '' }}</input>
+                <input class="form-control" id="new_email" name="new_email"
+                       placeholder="" value="{{ edit_form.new_email.data or '' }}">
                 {% for error in edit_form.new_email.errors %}
                   <div class="text-danger small mt-1">{{ error }}</div>
                 {% endfor %}
-                <div class="form-text mt-1"> 
-                  <span id="bio-count">{{ (edit_form.new_email.data or '') }}</span>
-                </div>
 
                 <label for="new_password" class="form-label" style="color: var(--pt-text-secondary);">Change Password</label>
-                <input class="form-control" id="new_password" name="new_password" rows="1"
-                          placeholder="" type="password">{{ edit_form.new_password.data or '' }}</input>
+                <input class="form-control" id="new_password" name="new_password" type="password"
+                       placeholder="">
                 {% for error in edit_form.new_password.errors %}
                   <div class="text-danger small mt-1">{{ error }}</div>
                 {% endfor %}
-                <div class="form-text mt-1"> 
-                  <span id="bio-count">{{ (edit_form.new_password.data or '') }}</span>
-                </div>
 
                 <label for="confirm_password" class="form-label" style="color: var(--pt-text-secondary);">Confirm Password</label>
-                <input class="form-control" id="confirm_password" name="confirm_password" rows="1"
-                          placeholder="" type = "password">{{ edit_form.confirm_password.data or '' }}</input>
+                <input class="form-control" id="confirm_password" name="confirm_password" type="password"
+                       placeholder="">
                 {% for error in edit_form.confirm_password.errors %}
                   <div class="text-danger small mt-1">{{ error }}</div>
                 {% endfor %}
-                <div class="form-text mt-1"> 
-                  <span id="bio-count">{{ (edit_form.confirm_password.data or '') }}</span>
-                </div>
 
                 <div class="mb-4">
                     <label for="image" class="form-label" style="color: var(--pt-text-secondary)">Profile Picture</label>

--- a/app/templates/auth/public_profile.html
+++ b/app/templates/auth/public_profile.html
@@ -95,12 +95,11 @@
       <div class="col-sm-6 col-lg-4">
         <div class="profile-recipe-card h-100">
           {% if recipe.image_filename %}
-          <img src="{{ url_for('static', filename='uploads/' + recipe.image_filename) }}"
+          <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
                alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
           {% else %}
-          <div class="card-img-placeholder">
-            <i class="bi bi-egg-fried"></i>
-          </div>
+          <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
           {% endif %}
           <div class="p-3">
             <h6 class="mb-1 fw-bold" style="color: var(--pt-text);">{{ recipe.title }}</h6>

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-12" style="max-width: 520px;">
-    <div class="card bg-dark border-secondary shadow">
+    <div class="card pt-panel shadow">
       <div class="card-body p-4">
         <h2 class="card-title text-center mb-4">
           <i class="bi bi-person-plus"></i> Create Account
@@ -16,7 +16,7 @@
 
           <div class="mb-3">
             {{ form.username.label(class="form-label") }}
-            {{ form.username(class="form-control text-light", placeholder="Choose a username") }}
+            {{ form.username(class="form-control", placeholder="Choose a username") }}
             {% for error in form.username.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}
@@ -24,7 +24,7 @@
 
           <div class="mb-3">
             {{ form.email.label(class="form-label") }}
-            {{ form.email(class="form-control text-light", placeholder="you@example.com") }}
+            {{ form.email(class="form-control", placeholder="you@example.com") }}
             {% for error in form.email.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}
@@ -32,7 +32,7 @@
 
           <div class="mb-3">
             {{ form.password.label(class="form-label") }}
-            {{ form.password(class="form-control text-light", placeholder="Minimum 8 characters") }}
+            {{ form.password(class="form-control", placeholder="Minimum 8 characters") }}
             {% for error in form.password.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}
@@ -40,7 +40,7 @@
 
           <div class="mb-3">
             {{ form.confirm_password.label(class="form-label") }}
-            {{ form.confirm_password(class="form-control text-light", placeholder="Re-enter password") }}
+            {{ form.confirm_password(class="form-control", placeholder="Re-enter password") }}
             {% for error in form.confirm_password.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}

--- a/app/templates/auth/users.html
+++ b/app/templates/auth/users.html
@@ -68,15 +68,16 @@
     let totalResults = "{{ total }}";
 
     function buildCardHtml(u) {
-        const imgBlock = u.avatar_url
-            ? `<img src=" ${u.avatar_url}" alt="${u.username}" class="rounded-circle" width="40" height="40"
-                         style="border:2px solid var(--pt-border)">`
+        // Render to match the server-rendered card layout in this file so the
+        // grid looks consistent before/after a search (avatar + name in a row).
+        const avatar = u.avatar_url
+            ? `<img src="${u.avatar_url}" alt="${u.username}" class="rounded-circle me-2" width="36">`
             : '';
         return `
-        <article class="pt-card h-100">
-            <div class="img-ph">${imgBlock}</div>
-            <h3><a href="/user/${u.username}" class="text-decoration-none" style="color:var(--pt-text);">${u.username}</a></h3>
-        </article>`;
+        <div class="card-body d-flex align-items-center mb-3" style="padding-bottom: 0">
+            ${avatar}
+            <a href="/user/${u.username}" class="me-auto">${u.username}</a>
+        </div>`;
     }
 
     function fetchUsers(append) {
@@ -99,7 +100,7 @@
 
                 data.users.forEach(u => {
                     const col = document.createElement('div');
-                    col.className = 'col-lg-3 col-md-4 col-sm-6';
+                    col.className = 'card mb-3 animate-fade col-lg-4 col-md-6 col-sm-6';
                     col.innerHTML = buildCardHtml(u);
                     grid.appendChild(col);
                 });


### PR DESCRIPTION
Closes #30 

Eight small post-merge fixes following code review of WORK-B. Person B approved me taking these on as a follow-up. Split into 3 logical commits.

## Bugs fixed

### Templates
1. **`auth/login.html` + `auth/register.html`** — cards used hardcoded `bg-dark border-secondary`, which doesn't follow the theme toggle. Replaced with the theme-aware `pt-panel` class and removed `text-light` from inputs (let them inherit theme color).

2. **`auth/profile.html` (3 bugs in one file)**:
   - Username error block used `{% if field == new_username %}` with `new_username` as an undefined Jinja variable (no quotes). Replaced with the standard `{% for error in edit_form.new_username.errors %}` pattern matching the email/password blocks.
   - Three `<input>` fields put their value between tags instead of in a `value=` attribute, and used invalid `</input>` closing tags. Result: fields didn't pre-populate after a failed validation. Fixed by moving values into `value="..."` attributes (omitted on password fields by design).
   - Four `<span>` elements all shared `id="bio-count"`. IDs must be unique. The bio counter still worked (JS finds the first one), but the duplicates rendered the user's plaintext email + password values as visible DOM text. Removed the three duplicates (kept the genuine bio counter).

3. **`auth/public_profile.html`** — image fallback was previously added (URL/filename autodetect + Loremflickr placeholder) but Person B's recent WORK-B PR overwrote it. Re-applied. Recipes with curated Wikimedia URLs now render correctly; recipes without an upload show a Loremflickr food photo instead of the egg-fried placeholder.

### Form validators (`auth/forms.py`)
4. `validate_new_username` and `validate_new_email` were:
   - Case-sensitive (`filter_by(username=field.data)`) but `routes.py:profile_edit` lowercases on save → entering "Alice" passed validation, then saving `alice` triggered DB IntegrityError → 500
   - Didn't exclude `User.id != current_user.id`, so re-submitting your own existing username falsely triggered "already taken"
   
   Both validators now: skip empty input (Optional), use `func.lower(...)` for case-insensitive comparison, and exclude the current user from the duplicate check.

### Backend + JS
5. **`/api/users` returned 500** — endpoint did `jsonify(users=users, ...)` where `users` is a list of SQLAlchemy `User` ORM rows. Flask can't serialise model instances → 500 → silent JS failure → search bar appeared dead. Fixed by serialising each User to a dict (`{id, username, avatar_url}`) before jsonify. Also clamped `page≥1` and `per_page` to ≤50 (same defensive pattern as `/api/recipes`).

6. **`users.html` `buildCardHtml`** — the JS-rendered search-result cards used `<article class="pt-card">` with different column classes than the server-rendered `<div class="card mb-3 animate-fade">` cards. After a search, the grid layout subtly shifted. Also had a leading space inside the img `src`. Fixed: card builder now matches the server template structure exactly.

## Testing

- `python -m unittest tests.unit.test_auth -v` → 4 tests pass
- `python -m unittest tests.unit.test_workc_routes -v` → 10 tests pass
- (One pre-existing unrelated error in `app/ai/routes.py` — `NameError: request is not defined` — that's WORK-D scope, separate)

## Manual verification

- Toggled theme on /login + /register — cards now follow ✓
- Submitted bad inputs to profile edit — errors now appear inline next to each field ✓
- Edited profile keeping same username — no false "already taken" ✓
- Tried to claim different-case version of an existing username — properly rejected with friendly error (no 500) ✓
- Typed in /users search bar — DevTools Network shows 200 JSON response, results render correctly ✓
- Clicked into another user's profile from community — recipe images render (Wikimedia for curated, Loremflickr for others) ✓

