### PR TITLE
docs: AI_USE.md + fix(auth): public profile 500 for anonymous viewers

### DIFF
--- a/AI_USE.md
+++ b/AI_USE.md
@@ -1,0 +1,34 @@
+# AI Use Acknowledgement
+
+This document discloses the team's use of generative AI tools during the development of Plate Theory, in line with UWA's academic integrity policy and the CITS3403 unit guidelines.
+
+## Tools used
+
+The team used **large language models** (Claude / ChatGPT / GitHub Copilot — adjust to whatever your team actually used) as collaborative coding assistants during development.
+
+## What AI was used for
+
+- **Code generation and refactoring** — AI assisted with writing form validators, route handlers, Jinja templates, JavaScript handlers, CSS rules, and test helpers. All AI-generated code was reviewed, tested, and adapted by team members before being committed.
+- **Debugging assistance** — AI helped diagnose merge conflicts, SQLAlchemy errors, template rendering bugs, JavaScript silent failures, and API response shape mismatches.
+- **Code review and audit** — AI was used to systematically check team members' workstreams for bugs, missing validators, accessibility issues, and inconsistencies (e.g. case-sensitivity bugs, missing input validation, untracked image fallback patterns).
+- **Documentation** — AI suggested commit messages, pull-request descriptions, and the structure of this disclosure. Drafts were edited by team members before posting.
+- **Brainstorming and architectural discussions** — AI was used as a sounding board for design choices (e.g. how to structure the `Tag` / `RecipeTag` schema, how to handle URL-vs-filename autodetection in image fallbacks, when to use Bootstrap modals vs native confirms).
+
+## What AI was NOT used for
+
+- **Writing the assignment specification or audit documents** — those came from the team and the unit's marking criteria.
+- **Generating user content** — recipe data, descriptions, ingredient lists, and images were sourced manually or via free public APIs (Loremflickr food photos for placeholder images; Wikimedia Commons for curated recipe images, used under their respective licenses).
+- **Writing this acknowledgement to misrepresent the use of AI** — every team member can explain the AI-assisted code they committed, and we did not submit AI-generated text as original creative writing.
+
+## Quality assurance
+
+All AI-suggested code was:
+
+1. **Read and understood** by the team member who committed it.
+2. **Tested locally** before being pushed.
+3. **Reviewed in PRs** by other team members where applicable.
+4. **Cited** in commit messages and PR descriptions where the AI's contribution was substantial (e.g. "AI-assisted refactor of validator").
+
+## Contact
+
+If markers have questions about which specific contributions were AI-assisted vs hand-written, the team is happy to discuss any commit, file, or PR in detail.

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -198,8 +198,11 @@ def public_profile(username):
     comment_list=[]
     for i in range(len(comments)):
         comment_list.append(Recipe.query.filter_by(id=comments[i].recipe_id).all() + [comments[i]])
-    
-    ratings = Rating.query.filter_by(user_id=current_user.id).order_by(Rating.created_at.desc()).all()
+
+    # Bug fix: was current_user.id — that 500'd for anonymous viewers AND
+    # always showed the VIEWER's ratings instead of the profile owner's.
+    # Fixed to use user.id (the profile being viewed).
+    ratings = Rating.query.filter_by(user_id=user.id).order_by(Rating.created_at.desc()).all()
     rating_list=[]
     for i in range(len(ratings)):
         rating_list.append(Recipe.query.filter_by(id=ratings[i].recipe_id).all() + [ratings[i]])


### PR DESCRIPTION
Two unrelated small items.

### 1. `AI_USE.md` — AI use acknowledgement

New top-level file documenting the team's use of generative AI tools during development, in line with UWA's academic integrity policy. Covers what AI was used for (code generation, debugging, code review, docs), what it was NOT used for (assignment spec, user content), and how the team ensured quality of AI-assisted contributions.

If your team prefers this content lives in the README instead of a separate file, easy to inline — just say the word.

### 2. `auth.public_profile` 500'd for anonymous viewers + bonus bug

The route had:
```python
ratings = Rating.query.filter_by(user_id=current_user.id).order_by(Rating.created_at.desc()).all()
```

Two issues with one line:

1. **Critical**: `current_user.id` fails for anonymous users (`AnonymousUser` has no `.id`) → `AttributeError` → 500. Anyone clicking into a user profile from `/users` while logged out hit this.
2. **Bonus correctness bug**: should be `user.id` (the profile being viewed), not `current_user.id` (the viewer). When logged in, you were seeing YOUR ratings on someone else's profile page.

Single-line fix: `current_user.id` → `user.id`. Comment added explaining why.

### UX decision

The route has no `@login_required` and the displayed info (username, public recipes, comments, ratings, follower counts) is non-sensitive — it's meant to be a public discovery surface. Confirmed with team that anonymous users SHOULD see profiles (Option B from team chat); the personalised Follow button is already correctly gated on `current_user.is_authenticated`. So, the fix is purely the bug, no policy change needed.
