### PR TITLE
UX polish + reactive UI + themed dialogs

### DIFF
--- a/app/recipes/routes.py
+++ b/app/recipes/routes.py
@@ -416,10 +416,17 @@ def rate(slug):
 
     db.session.commit()
 
+    # Build the 1..5 distribution so the breakdown bars can update without a reload.
+    distribution = {i: 0 for i in range(1, 6)}
+    for r in recipe.ratings.all():
+        if r.score in distribution:
+            distribution[r.score] += 1
+
     return jsonify(
         success=True,
         avg_rating=recipe.avg_rating,
         rating_count=recipe.rating_count,
+        distribution=distribution,
     )
 
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -711,6 +711,59 @@ textarea.form-control {
   color: var(--pt-violet);
 }
 
+/* Clickable badges (rendered as <a>) — subtle lift + brighten on hover. */
+a.badge {
+  transition: background-color 0.18s ease,
+              color 0.18s ease,
+              transform 0.18s ease,
+              box-shadow 0.18s ease;
+}
+
+a.badge:hover,
+a.badge:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  text-decoration: none;
+}
+
+a.badge.bg-info:hover,
+a.badge.bg-info:focus-visible {
+  background: rgba(179, 136, 255, 0.28) !important;
+  color: var(--pt-violet);
+}
+
+a.badge.bg-primary:hover,
+a.badge.bg-primary:focus-visible {
+  background: rgba(94, 245, 192, 0.28) !important;
+  color: var(--pt-mint);
+}
+
+a.badge.bg-success:hover,
+a.badge.bg-success:focus-visible {
+  background: rgba(94, 245, 192, 0.28) !important;
+  color: var(--pt-mint);
+}
+
+a.badge.bg-warning:hover,
+a.badge.bg-warning:focus-visible {
+  background: rgba(255, 217, 61, 0.24) !important;
+  color: var(--pt-sun);
+}
+
+a.badge.bg-danger:hover,
+a.badge.bg-danger:focus-visible {
+  background: rgba(255, 123, 137, 0.28) !important;
+  color: var(--pt-coral);
+}
+
+/* Category pill on profile pages uses an inline violet background rather than
+   .bg-info, so target it via the inline-style cue (still a hover shift). */
+a.badge[style*="violet"]:hover,
+a.badge[style*="179,136,255"]:hover,
+a.badge[style*="179, 136, 255"]:hover {
+  background: rgba(179, 136, 255, 0.28) !important;
+}
+
 /* --- Tables --- */
 .table {
   color: var(--pt-text);

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1408,6 +1408,7 @@ footer p {
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, var(--pt-sun), var(--pt-mint));
+  transition: width 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
 .rating-breakdown-count {

--- a/app/static/js/discover.js
+++ b/app/static/js/discover.js
@@ -197,7 +197,7 @@
         } else {
             imgSrc = `https://loremflickr.com/600/400/${slugTags},food?lock=${r.id}`;
         }
-        const mediaBlock = `<img src="${imgSrc}" alt="${escapeHtml(r.title)}">`;
+        const mediaBlock = `<img src="${imgSrc}" alt="${escapeHtml(r.title)}" loading="lazy">`;
 
         const stars = Array.from({ length: 5 }, (_, i) =>
             `<i class="bi bi-star${i < Math.round(r.avg_rating || 0) ? '-fill' : ''}"></i>`

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -81,10 +81,65 @@ function autoDismissAlerts() {
     });
 }
 
-function confirmAction(title, message, callback) {
-    if (confirm(`${title}\n\n${message}`)) {
-        callback();
+/* ── Styled confirm modal ──
+ * Themed equivalent of native confirm(). Uses #ptConfirmModal defined in base.html.
+ * Returns a Promise<boolean> that resolves true on Confirm, false on Cancel/close.
+ *
+ *   ptConfirm({ title, message, confirmText, cancelText, variant }) → Promise<bool>
+ *
+ * `variant` toggles the confirm button colour: 'danger' (default) = coral, 'primary' = mint.
+ */
+function ptConfirm(opts) {
+    opts = opts || {};
+    const modalEl   = document.getElementById('ptConfirmModal');
+    if (!modalEl || !window.bootstrap) {
+        // Graceful fallback if base.html modal is somehow missing.
+        return Promise.resolve(window.confirm((opts.title ? opts.title + '\n\n' : '') + (opts.message || 'Are you sure?')));
     }
+    const titleEl   = modalEl.querySelector('#ptConfirmTitle');
+    const bodyEl    = modalEl.querySelector('#ptConfirmBody');
+    const okBtn     = modalEl.querySelector('#ptConfirmOk');
+    const cancelBtn = modalEl.querySelector('#ptConfirmCancel');
+
+    titleEl.textContent = opts.title   || 'Confirm';
+    bodyEl.textContent  = opts.message || 'Are you sure?';
+    okBtn.textContent   = opts.confirmText || 'Confirm';
+    cancelBtn.textContent = opts.cancelText || 'Cancel';
+
+    // Reset variant classes
+    okBtn.classList.remove('btn-coral', 'btn-mint', 'btn-outline-mint');
+    okBtn.classList.add(opts.variant === 'primary' ? 'btn-mint' : 'btn-coral');
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    return new Promise((resolve) => {
+        let resolved = false;
+        function onOk() {
+            resolved = true;
+            cleanup();
+            modal.hide();
+            resolve(true);
+        }
+        function onHidden() {
+            if (!resolved) {
+                cleanup();
+                resolve(false);
+            }
+        }
+        function cleanup() {
+            okBtn.removeEventListener('click', onOk);
+            modalEl.removeEventListener('hidden.bs.modal', onHidden);
+        }
+        okBtn.addEventListener('click', onOk);
+        modalEl.addEventListener('hidden.bs.modal', onHidden);
+        modal.show();
+    });
+}
+window.ptConfirm = ptConfirm;
+
+// Backward-compat: existing confirmAction(title, message, callback) callers still work,
+// but now they see the styled modal instead of the browser dialog.
+function confirmAction(title, message, callback) {
+    ptConfirm({ title: title, message: message }).then((ok) => { if (ok) callback(); });
 }
 
 function showSpinner(container) {
@@ -428,6 +483,38 @@ function initGroceryCheck() {
     });
 }
 
+/* ── Global form-level confirm interceptor ──
+ * Any <form class="pt-confirm-form"> will route its submit through the styled
+ * ptConfirm modal instead of native confirm(). Configure per-form via data-*:
+ *   data-confirm-title   — modal title       (default: "Confirm")
+ *   data-confirm-message — modal body text   (default: "Are you sure?")
+ *   data-confirm-text    — primary btn label (default: "Confirm")
+ *   data-confirm-variant — "danger" (default coral) | "primary" (mint)
+ *
+ * Uses delegation so dynamically-added forms work too.
+ */
+function initConfirmForms() {
+    document.addEventListener('submit', function (e) {
+        const form = e.target;
+        if (!(form instanceof HTMLFormElement)) return;
+        if (!form.classList.contains('pt-confirm-form')) return;
+        if (form.dataset.ptConfirmed === '1') return;  // already approved — let it through
+
+        e.preventDefault();
+        ptConfirm({
+            title:       form.dataset.confirmTitle   || 'Confirm',
+            message:     form.dataset.confirmMessage || 'Are you sure?',
+            confirmText: form.dataset.confirmText    || 'Confirm',
+            variant:     form.dataset.confirmVariant || 'danger',
+        }).then(function (ok) {
+            if (ok) {
+                form.dataset.ptConfirmed = '1';
+                form.submit();
+            }
+        });
+    });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     autoDismissAlerts();
     initScrollReveal();
@@ -435,4 +522,5 @@ document.addEventListener('DOMContentLoaded', () => {
     initHeadingReveal();
     initCountUp();
     initGroceryCheck();
+    initConfirmForms();
 });

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -25,9 +25,29 @@ function toggleFollow(username, btn) {
   })
   .then(r => r.json())
   .then(data => {
-    if (data.success) {
-      btn.dataset.following = !isFollowing;
-      btn.textContent = isFollowing ? 'Follow' : 'Unfollow';
+    if (!data.success) return;
+
+    // 1. Flip the clicked button + any other follow-button for the SAME user
+    //    on this page (e.g. recipe cards showing the same creator).
+    document.querySelectorAll(`.follow-btn[data-username="${username}"], button[data-username="${username}"]`).forEach(b => {
+      b.dataset.following = String(!isFollowing);
+      b.textContent = isFollowing ? 'Follow' : 'Unfollow';
+    });
+
+    // 2. Update FOLLOWER COUNT — only if the displayed count belongs to the
+    //    user we just followed/unfollowed (matched via data-username).
+    const followerEl = document.getElementById('profile-follower-count');
+    if (followerEl && followerEl.dataset.username === username && typeof data.follower_count === 'number') {
+      followerEl.textContent = data.follower_count;
+    }
+
+    // 3. Update FOLLOWING COUNT — only if we're on the CURRENT USER's own
+    //    profile (their following count changed by ±1).
+    const currentUser = document.querySelector('meta[name="current-user"]')?.content || '';
+    const followingEl = document.getElementById('profile-following-count');
+    if (followingEl && followingEl.dataset.username === currentUser && currentUser) {
+      const delta = isFollowing ? -1 : 1;
+      followingEl.textContent = (parseInt(followingEl.textContent, 10) || 0) + delta;
     }
   })
   .catch(() => showErrorToast('Could not update follow status.'));

--- a/app/static/js/pantry.js
+++ b/app/static/js/pantry.js
@@ -187,7 +187,7 @@
                 } else {
                     imgSrc = `https://loremflickr.com/600/400/${slugTags},food?lock=${m.recipe_id}`;
                 }
-                const imgEl = `<img src="${imgSrc}" alt="${escapeHtml(m.title)}"
+                const imgEl = `<img src="${imgSrc}" alt="${escapeHtml(m.title)}" loading="lazy"
                              style="width:100%;height:120px;object-fit:cover;border-radius:12px;margin-bottom:0.5rem;">`;
                 const imgLink = m.slug
                     ? `<a href="/recipe/${escapeHtml(m.slug)}" class="d-block" aria-label="View ${escapeHtml(m.title)}">${imgEl}</a>`
@@ -325,11 +325,11 @@
                             '</div>';
                     }
                 } else {
-                    alert(res.data.error || 'Could not save recipe.');
+                    showErrorToast(res.data.error || 'Could not save recipe.');
                 }
             })
             .catch(() => {
-                alert('Network error — please try again.');
+                showErrorToast('Network error — please try again.');
             })
             .finally(() => {
                 buttons.forEach(b => { b.disabled = false; });
@@ -337,11 +337,18 @@
     });
 
     if (feedbackEl) {
-        feedbackEl.addEventListener('click', function (e) {
+        feedbackEl.addEventListener('click', async function (e) {
             const pub = e.target.closest('.btn-feedback-publish');
             if (!pub) return;
             const slug = pub.dataset.slug;
-            if (!slug || !confirm('Publish this recipe for everyone to see?')) return;
+            if (!slug) return;
+            const ok = await ptConfirm({
+                title: 'Publish recipe?',
+                message: 'Publish this recipe for everyone to see?',
+                confirmText: 'Publish',
+                variant: 'primary',
+            });
+            if (!ok) return;
             pub.disabled = true;
             fetch('/api/recipe/' + encodeURIComponent(slug) + '/visibility', {
                 method: 'POST',
@@ -353,12 +360,12 @@
                     if (res.ok && res.data.success) {
                         window.location.href = '/recipe/' + encodeURIComponent(slug);
                     } else {
-                        alert(res.data.error || 'Could not publish.');
+                        showErrorToast(res.data.error || 'Could not publish.');
                         pub.disabled = false;
                     }
                 })
                 .catch(() => {
-                    alert('Network error.');
+                    showErrorToast('Network error.');
                     pub.disabled = false;
                 });
         });

--- a/app/templates/auth/profile.html
+++ b/app/templates/auth/profile.html
@@ -25,11 +25,13 @@
           <div class="stat-label">Avg Rating</div>
         </div>
         <div class="profile-stat" onclick="openFollow('followers')">
-          <div class="stat-number text-violet">{{ follower_count }}</div>
+          <div class="stat-number text-violet" id="profile-follower-count"
+               data-username="{{ current_user.username }}">{{ follower_count }}</div>
           <div class="stat-label">Followers</div>
         </div>
         <div class="profile-stat" onclick="openFollow('following')">
-          <div class="stat-number text-mint">{{ following_count }}</div>
+          <div class="stat-number text-mint" id="profile-following-count"
+               data-username="{{ current_user.username }}">{{ following_count }}</div>
           <div class="stat-label">Following</div>
         </div>
       </div>
@@ -102,10 +104,10 @@
         <div class="profile-recipe-card h-100">
           {% if recipe.image_filename %}
           <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
-               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;" loading="lazy">
           {% else %}
           <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
-               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;" loading="lazy">
           {% endif %}
           <div class="p-3">
             <h6 class="mb-1 fw-bold" style="color: var(--pt-text);">{{ recipe.title }}</h6>
@@ -128,8 +130,10 @@
               <a href="/recipe/{{ recipe.slug }}/edit" class="btn btn-sm btn-outline-light">
                 <i class="bi bi-pencil"></i>
               </a>
-              <form action="/recipe/{{ recipe.slug }}/delete" method="POST" class="d-inline"
-                    onsubmit="return confirm('Delete this recipe?');">
+              <form action="/recipe/{{ recipe.slug }}/delete" method="POST" class="d-inline pt-confirm-form"
+                    data-confirm-title="Delete recipe?"
+                    data-confirm-message="Delete &ldquo;{{ recipe.title }}&rdquo;? This cannot be undone."
+                    data-confirm-text="Delete">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn btn-sm btn-outline-coral" aria-label="Delete recipe">
                   <i class="bi bi-trash"></i>
@@ -160,10 +164,10 @@
         <div class="profile-recipe-card h-100">
           {% if recipe.image_filename %}
           <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
-               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;" loading="lazy">
           {% else %}
           <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
-               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;" loading="lazy">
           {% endif %}
           <div class="p-3">
             <h6 class="mb-1 fw-bold" style="color: var(--pt-text);">{{ recipe.title }}</h6>

--- a/app/templates/auth/public_profile.html
+++ b/app/templates/auth/public_profile.html
@@ -98,10 +98,10 @@
         <div class="profile-recipe-card h-100">
           {% if recipe.image_filename %}
           <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
-               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;" loading="lazy">
           {% else %}
           <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
-               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;">
+               alt="{{ recipe.title }}" style="width:100%;height:180px;object-fit:cover;border-radius:0;" loading="lazy">
           {% endif %}
           <div class="p-3">
             <h6 class="mb-1 fw-bold" style="color: var(--pt-text);">{{ recipe.title }}</h6>
@@ -163,8 +163,9 @@
     </div>
     {% else %}
     <div class="text-center py-5" style="color: var(--pt-muted);">
-      <i class="bi bi-chat-dots" style="font-size: 2.5rem; color: var(--pt-violet);"></i>
-      <p class="mt-3 mb-1 fw-bold" style="color: var(--pt-text);">No ratings</p>
+      <i class="bi bi-star" style="font-size: 2.5rem; color: var(--pt-sun);"></i>
+      <p class="mt-3 mb-1 fw-bold" style="color: var(--pt-text);">No ratings yet</p>
+      <p style="font-size:.85rem;color: var(--pt-muted);">{{ user.username }} hasn't rated any recipes.</p>
     </div>
     {% endif %}
   </div>
@@ -191,7 +192,8 @@
     {% else %}
     <div class="text-center py-5" style="color: var(--pt-muted);">
       <i class="bi bi-chat-dots" style="font-size: 2.5rem; color: var(--pt-violet);"></i>
-      <p class="mt-3 mb-1 fw-bold" style="color: var(--pt-text);">No commments</p>
+      <p class="mt-3 mb-1 fw-bold" style="color: var(--pt-text);">No comments yet</p>
+      <p style="font-size:.85rem;color: var(--pt-muted);">{{ user.username }} hasn't posted any comments.</p>
     </div>
     {% endif %}
   </div>

--- a/app/templates/auth/public_profile.html
+++ b/app/templates/auth/public_profile.html
@@ -33,11 +33,13 @@
           <div class="stat-label">Avg Rating</div>
         </div>
         <div class="profile-stat" onclick="openFollow('followers')">
-          <div class="stat-number text-violet">{{ follower_count }}</div>
+          <div class="stat-number text-violet" id="profile-follower-count"
+               data-username="{{ user.username }}">{{ follower_count }}</div>
           <div class="stat-label">Followers</div>
         </div>
         <div class="profile-stat" onclick="openFollow('following')">
-          <div class="stat-number text-mint">{{ following_count }}</div>
+          <div class="stat-number text-mint" id="profile-following-count"
+               data-username="{{ user.username }}">{{ following_count }}</div>
           <div class="stat-label">Following</div>
         </div>
       </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -115,6 +115,25 @@
         <p class="mb-0 text-muted-custom">Plate Theory &copy; {{ current_year }} | CITS3403 Group Project</p>
     </footer>
 
+    <!-- Global styled confirmation modal — used by window.ptConfirm() to replace native confirm() -->
+    <div class="modal fade" id="ptConfirmModal" tabindex="-1" aria-labelledby="ptConfirmTitle" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content pt-panel">
+          <div class="modal-header">
+            <h5 class="modal-title" id="ptConfirmTitle">Confirm</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body" id="ptConfirmBody" style="color: var(--pt-text);">
+            Are you sure?
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal" id="ptConfirmCancel">Cancel</button>
+            <button type="button" class="btn btn-coral" id="ptConfirmOk">Confirm</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
       (function() {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="current-user" content="{{ current_user.username if current_user.is_authenticated else '' }}">
     <title>{% block title %}Plate Theory{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/app/templates/community/feed.html
+++ b/app/templates/community/feed.html
@@ -56,11 +56,11 @@
                                               else 'https://loremflickr.com/600/400/' ~ recipe.slug|replace('-', ',') ~ ',food?lock=' ~ recipe.id) %}
                             {% if recipe.slug %}
                             <a href="/recipe/{{ recipe.slug }}" class="pt-card-media d-block" aria-label="View {{ recipe.title }}">
-                                <img src="{{ _img_src }}" alt="{{ recipe.title }}">
+                                <img src="{{ _img_src }}" alt="{{ recipe.title }}" loading="lazy">
                             </a>
                             {% else %}
                             <div class="pt-card-media">
-                                <img src="{{ _img_src }}" alt="{{ recipe.title }}">
+                                <img src="{{ _img_src }}" alt="{{ recipe.title }}" loading="lazy">
                             </div>
                             {% endif %}
                             <h3>

--- a/app/templates/partials/_recipe_card.html
+++ b/app/templates/partials/_recipe_card.html
@@ -1,9 +1,9 @@
 <article class="pt-card h-100">
     <a href="/recipe/{{ recipe.slug }}" class="pt-card-media d-block" aria-label="View {{ recipe.title }}">
         {% if recipe.image_filename %}
-        <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}" alt="{{ recipe.title }}">
+        <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}" alt="{{ recipe.title }}" loading="lazy">
         {% else %}
-        <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}" alt="{{ recipe.title }}">
+        <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}" alt="{{ recipe.title }}" loading="lazy">
         {% endif %}
     </a>
     <h3><a href="/recipe/{{ recipe.slug }}" class="text-decoration-none" style="color: var(--pt-text);">{{ recipe.title }}</a></h3>

--- a/app/templates/recipes/_my_meal_card.html
+++ b/app/templates/recipes/_my_meal_card.html
@@ -6,11 +6,11 @@
             {% if recipe.image_filename %}
             <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
                  alt="{{ recipe.title }}"
-                 style="width:100%;height:160px;object-fit:cover;border-radius:12px;display:block;margin:0;">
+                 style="width:100%;height:160px;object-fit:cover;border-radius:12px;display:block;margin:0;" loading="lazy">
             {% else %}
             <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
                  alt="{{ recipe.title }}"
-                 style="width:100%;height:160px;object-fit:cover;border-radius:12px;display:block;margin:0;">
+                 style="width:100%;height:160px;object-fit:cover;border-radius:12px;display:block;margin:0;" loading="lazy">
             {% endif %}
         </a>
         {% else %}
@@ -18,12 +18,12 @@
             <img src="{{ recipe.image_filename if recipe.image_filename.startswith('http') else url_for('static', filename='uploads/' + recipe.image_filename) }}"
                  alt="{{ recipe.title }}"
                  style="width:100%;height:160px;object-fit:cover;border-radius:12px;opacity:0.45;filter:grayscale(0.5);display:block;"
-                 class="mb-2">
+                 class="mb-2" loading="lazy">
             {% else %}
             <img src="https://loremflickr.com/600/400/{{ recipe.slug|replace('-', ',') }},food?lock={{ recipe.id }}"
                  alt="{{ recipe.title }}"
                  style="width:100%;height:160px;object-fit:cover;border-radius:12px;opacity:0.45;filter:grayscale(0.5);display:block;"
-                 class="mb-2">
+                 class="mb-2" loading="lazy">
             {% endif %}
         {% endif %}
         <div class="d-flex justify-content-between align-items-start mb-2">
@@ -83,7 +83,10 @@
                 <i class="bi bi-lock me-1"></i> Make private
             </button>
             {% endif %}
-            <form method="POST" action="/recipe/{{ recipe.slug }}/delete" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this recipe?');">
+            <form method="POST" action="/recipe/{{ recipe.slug }}/delete" class="d-inline pt-confirm-form"
+                  data-confirm-title="Delete recipe?"
+                  data-confirm-message="Delete &ldquo;{{ recipe.title }}&rdquo;? This cannot be undone."
+                  data-confirm-text="Delete">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn btn-sm btn-outline-coral">
                     <i class="bi bi-trash me-1"></i> Delete

--- a/app/templates/recipes/detail.html
+++ b/app/templates/recipes/detail.html
@@ -84,7 +84,10 @@
             <a href="{{ url_for('recipes.edit', slug=recipe.slug) }}" class="btn btn-sm btn-outline-light">
                 <i class="bi bi-pencil me-1"></i> Edit
             </a>
-            <form method="POST" action="{{ url_for('recipes.delete', slug=recipe.slug) }}" class="d-inline" onsubmit="return confirm('Delete this recipe? This cannot be undone.');">
+            <form method="POST" action="{{ url_for('recipes.delete', slug=recipe.slug) }}" class="d-inline pt-confirm-form"
+                  data-confirm-title="Delete recipe?"
+                  data-confirm-message="Delete &ldquo;{{ recipe.title }}&rdquo;? This cannot be undone."
+                  data-confirm-text="Delete">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn btn-sm btn-outline-coral">
                     <i class="bi bi-trash me-1"></i> Delete
@@ -163,7 +166,7 @@
         {% for score in [5, 4, 3, 2, 1] %}
         {% set count = rating_distribution[score] %}
         {% set pct = (count / rating_count * 100) if rating_count else 0 %}
-        <div class="rating-breakdown-row">
+        <div class="rating-breakdown-row" data-score="{{ score }}">
             <span class="rating-breakdown-label">{{ score }} <i class="bi bi-star-fill" aria-hidden="true"></i></span>
             <div class="rating-breakdown-bar">
                 <div class="rating-breakdown-fill" style="width: {{ pct }}%;"></div>
@@ -334,6 +337,19 @@
                         s.className = idx < filled ? 'bi bi-star-fill' : 'bi bi-star';
                         s.setAttribute('aria-checked', String(parseInt(s.dataset.value, 10) === score));
                     });
+                    // Update breakdown bars + counts from the new distribution
+                    if (data.distribution && data.rating_count) {
+                        for (let s = 1; s <= 5; s++) {
+                            const row = document.querySelector(`.rating-breakdown-row[data-score="${s}"]`);
+                            if (!row) continue;
+                            const count = data.distribution[s] || 0;
+                            const pct = data.rating_count > 0 ? (count / data.rating_count * 100) : 0;
+                            const fill = row.querySelector('.rating-breakdown-fill');
+                            const countEl = row.querySelector('.rating-breakdown-count');
+                            if (fill) fill.style.width = pct + '%';
+                            if (countEl) countEl.textContent = count;
+                        }
+                    }
                     showToast('Thanks for rating!');
                 } else if (data.error) {
                     showErrorToast(data.error);
@@ -549,24 +565,35 @@
 
     const pubBtn = document.getElementById('recipe-publish-btn');
     if (pubBtn) {
-        pubBtn.addEventListener('click', () => {
-            if (!confirm('Publish this recipe? It will be visible to everyone.')) return;
+        pubBtn.addEventListener('click', async () => {
+            const ok = await ptConfirm({
+                title: 'Publish recipe?',
+                message: 'Publish this recipe? It will be visible to everyone.',
+                confirmText: 'Publish',
+                variant: 'primary',
+            });
+            if (!ok) return;
             pubBtn.disabled = true;
             postVisibility(true).then(res => {
                 if (res.ok && res.data.success) window.location.reload();
-                else { alert(res.data.error || 'Could not publish.'); pubBtn.disabled = false; }
-            }).catch(() => { alert('Network error.'); pubBtn.disabled = false; });
+                else { showErrorToast(res.data.error || 'Could not publish.'); pubBtn.disabled = false; }
+            }).catch(() => { showErrorToast('Network error.'); pubBtn.disabled = false; });
         });
     }
     const unpubBtn = document.getElementById('recipe-unpublish-btn');
     if (unpubBtn) {
-        unpubBtn.addEventListener('click', () => {
-            if (!confirm('Make this recipe private? It will no longer be visible to others.')) return;
+        unpubBtn.addEventListener('click', async () => {
+            const ok = await ptConfirm({
+                title: 'Make recipe private?',
+                message: 'Make this recipe private? It will no longer be visible to others.',
+                confirmText: 'Make private',
+            });
+            if (!ok) return;
             unpubBtn.disabled = true;
             postVisibility(false).then(res => {
                 if (res.ok && res.data.success) window.location.reload();
-                else { alert(res.data.error || 'Could not make private.'); unpubBtn.disabled = false; }
-            }).catch(() => { alert('Network error.'); unpubBtn.disabled = false; });
+                else { showErrorToast(res.data.error || 'Could not make private.'); unpubBtn.disabled = false; }
+            }).catch(() => { showErrorToast('Network error.'); unpubBtn.disabled = false; });
         });
     }
 

--- a/app/templates/recipes/my_meals.html
+++ b/app/templates/recipes/my_meals.html
@@ -74,12 +74,12 @@
                 if (res.ok && res.data.success) {
                     window.location.reload();
                 } else {
-                    alert(res.data.error || 'Could not update visibility.');
+                    showErrorToast(res.data.error || 'Could not update visibility.');
                     btn.disabled = false;
                 }
             })
             .catch(function () {
-                alert('Network error.');
+                showErrorToast('Network error.');
                 btn.disabled = false;
             });
     });


### PR DESCRIPTION
## Summary
A polish-and-bugfix pass before final submission. Removes every native browser
dialog from the site, makes the UI react without manual refreshes, fixes a few
silent bugs, and applies small visual touches.

## What changed

### Themed dialogs (replaces native confirm/alert everywhere)
- New reusable `window.ptConfirm({title, message, confirmText, variant})` returns
  a Promise — defined in `app/static/js/main.js`, modal markup lives in `base.html`.
- New `<form class="pt-confirm-form" data-confirm-title="…" data-confirm-message="…">`
  pattern — any form with that class is auto-intercepted by `main.js` and routed
  through the styled modal instead of the native browser dialog.
- `confirmAction()` kept as a backward-compat wrapper so older callers still work.
- Replaced **6 native `confirm()`** calls (profile delete recipe, detail page
  delete / publish / make-private, my-meal card delete, pantry publish).
- Replaced **8 native `alert()`** calls with `showErrorToast()` (pantry save +
  publish errors, detail publish/private errors, my-meals visibility error).

### Reactive UI (no more manual refresh)
- Star rating breakdown bars slide smoothly when a rating changes —
  added `transition: width 0.45s cubic-bezier(0.22, 0.61, 0.36, 1)`.
- Follower / following counts update live after Follow/Unfollow, both on
  `/profile` (own profile) and `/user/<username>` (other users' profiles).
  Disambiguated via `data-username` on the count elements + `<meta name="current-user">`.
- Newly-posted comments now render with the same Edit/Delete buttons that
  server-rendered comments have, no reload needed.
- Follow button state syncs across every `[data-username="…"]` button on the page
  so feed + card + profile all flip together.

### UX polish
- Recipe card images are now clickable everywhere — Home, Discover, Community,
  Pantry AI matched-recipe results, profile pages — wrapped in `<a>` so the whole
  image goes to the recipe detail page.
- Category badges (`dessert`, `vegan`, etc.) are clickable links to
  `/discover?category=X` on the community feed, profile pages, and recipe detail.
- Added subtle hover state on clickable badges (1px lift + tinted background +
  soft shadow) using a new `a.badge:hover` rule.
- `loading="lazy"` added to every recipe-card `<img>` (faster first paint when
  scrolling lists of cards).
- Empty states on the profile **Ratings** and **Comments** tabs now show an icon
  + friendly copy instead of nothing; fixed typo "commments" → "comments".
- Removed the Notes textarea from the "Add to Meal Plan" modal — wasn't
  persisted anywhere, just confusing.

## Files touched
- `app/templates/base.html` — global ptConfirm modal markup, current-user meta tag
- `app/templates/auth/profile.html`, `auth/public_profile.html` — clickable
  badges, reactive count IDs, loading="lazy", empty states, themed delete confirm
- `app/templates/recipes/detail.html` — SyntaxError fix, lightbox, themed
  delete/publish/private confirms, styled delete-comment modal, distribution bars
- `app/templates/recipes/_my_meal_card.html`, `my_meals.html` — themed dialogs,
  loading="lazy"
- `app/templates/recipes/_recipe_card.html`, `community/feed.html` —
  clickable image wrappers, clickable category badges, loading="lazy"
- `app/templates/planner/planner.html` — Remove Meal modal
- `app/static/js/main.js` — `ptConfirm()`, `.pt-confirm-form` interceptor,
  reactive follow count updates, backward-compat `confirmAction`
- `app/static/js/discover.js`, `pantry.js`, `planner.js` — image wrappers,
  themed dialogs, Chrome option.hidden workaround
- `app/static/css/style.css` — rating-breakdown transition, `a.badge:hover` state

## Testing
- All existing pytest tests pass locally.
- Manually clicked every replaced dialog and verified the styled modal appears
  with the right title / body / button colour.
- Verified follow/unfollow updates counts correctly on both profile pages and
  in the followers/following modal lists.
- Verified rating bars animate smoothly when changing your own rating.