### PR TITLE
fix: codebase audit — N+1 queries, dead code, missing CSS, broken search

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -91,15 +91,21 @@ def profile():
     follower_count = Follower.query.filter_by(followed_id=current_user.id).count()
     following_count = Follower.query.filter_by(follower_id=current_user.id).count()
 
-    comments = Comment.query.filter_by(user_id=current_user.id).order_by(Comment.created_at.desc()).all()
-    comment_list=[]
-    for i in range(len(comments)):
-        comment_list.append(Recipe.query.filter_by(id=comments[i].recipe_id).all() + [comments[i]])
+    comment_list = (
+        db.session.query(Recipe, Comment)
+        .join(Comment, Comment.recipe_id == Recipe.id)
+        .filter(Comment.user_id == current_user.id)
+        .order_by(Comment.created_at.desc())
+        .all()
+    )
 
-    ratings = Rating.query.filter_by(user_id=current_user.id).order_by(Rating.created_at.desc()).all()
-    rating_list=[]
-    for i in range(len(ratings)):
-        rating_list.append(Recipe.query.filter_by(id=ratings[i].recipe_id).all() + [ratings[i]])
+    rating_list = (
+        db.session.query(Recipe, Rating)
+        .join(Rating, Rating.recipe_id == Recipe.id)
+        .filter(Rating.user_id == current_user.id)
+        .order_by(Rating.created_at.desc())
+        .all()
+    )
 
     edit_form = EditProfileForm(obj=current_user)
 
@@ -194,18 +200,21 @@ def public_profile(username):
         )
         avg_rating = round(result, 1) if result else 0.0
 
-    comments = Comment.query.filter_by(user_id=user.id).order_by(Comment.created_at.desc()).all()
-    comment_list=[]
-    for i in range(len(comments)):
-        comment_list.append(Recipe.query.filter_by(id=comments[i].recipe_id).all() + [comments[i]])
+    comment_list = (
+        db.session.query(Recipe, Comment)
+        .join(Comment, Comment.recipe_id == Recipe.id)
+        .filter(Comment.user_id == user.id)
+        .order_by(Comment.created_at.desc())
+        .all()
+    )
 
-    # Bug fix: was current_user.id — that 500'd for anonymous viewers AND
-    # always showed the VIEWER's ratings instead of the profile owner's.
-    # Fixed to use user.id (the profile being viewed).
-    ratings = Rating.query.filter_by(user_id=user.id).order_by(Rating.created_at.desc()).all()
-    rating_list=[]
-    for i in range(len(ratings)):
-        rating_list.append(Recipe.query.filter_by(id=ratings[i].recipe_id).all() + [ratings[i]])
+    rating_list = (
+        db.session.query(Recipe, Rating)
+        .join(Rating, Rating.recipe_id == Recipe.id)
+        .filter(Rating.user_id == user.id)
+        .order_by(Rating.created_at.desc())
+        .all()
+    )
 
     follower_count = Follower.query.filter_by(followed_id=user.id).count()
     following_count = Follower.query.filter_by(follower_id=user.id).count()
@@ -228,11 +237,14 @@ def public_profile(username):
 
 @bp.route('/users')
 def users():
-    q = ''
-    users = User.query.filter(User.username.ilike(f'%{q}%')).limit(20).all()
-    total = len(users)
-    has_next = 12<total
-    return render_template('auth/users.html', users=users, total=total, has_next=has_next)
+    q = request.args.get('q', '', type=str).strip()
+    query = User.query
+    if q:
+        query = query.filter(User.username.ilike(f'%{q}%'))
+    users = query.order_by(User.username).limit(20).all()
+    total = query.count()
+    has_next = total > 20
+    return render_template('auth/users.html', users=users, total=total, has_next=has_next, q=q)
 
 
 @bp.route('/api/users')

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -764,6 +764,24 @@ a.badge[style*="179, 136, 255"]:hover {
   background: rgba(179, 136, 255, 0.28) !important;
 }
 
+/* AI-generated recipe badge */
+.badge-ai {
+  background: linear-gradient(135deg, rgba(179,136,255,0.18), rgba(94,245,192,0.14));
+  color: var(--pt-violet);
+  border: 1px solid rgba(179,136,255,0.3);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.2em 0.5em;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+[data-theme="light"] .badge-ai {
+  background: rgba(124,77,255,0.08);
+  color: var(--pt-violet);
+  border-color: rgba(124,77,255,0.25);
+}
+
 /* --- Tables --- */
 .table {
   color: var(--pt-text);

--- a/app/static/js/discover.js
+++ b/app/static/js/discover.js
@@ -230,11 +230,7 @@
         </article>`;
     }
 
-    function escapeHtml(str) {
-        const div = document.createElement('div');
-        div.appendChild(document.createTextNode(str));
-        return div.innerHTML;
-    }
+    // escapeHtml is provided globally by main.js
 
     /* ── Restore state on Back/Forward ── */
     window.addEventListener('popstate', (e) => {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -7,16 +7,6 @@ function escapeHtml(s) {
 }
 window.escapeHtml = escapeHtml;
 
-function showErrorToast(message) {
-  const el = document.createElement('div');
-  el.className = 'alert alert-danger position-fixed bottom-0 end-0 m-3';
-  el.style.zIndex = 9999;
-  el.textContent = message;
-  document.body.appendChild(el);
-  setTimeout(() => el.remove(), 4000);
-}
-window.showErrorToast = showErrorToast;
-
 function toggleFollow(username, btn) {
   const isFollowing = btn.dataset.following === 'true';
   fetch(`/user/${username}/follow`, {

--- a/app/static/js/pantry.js
+++ b/app/static/js/pantry.js
@@ -16,12 +16,7 @@
             .map(c => c.dataset.name);
     }
 
-    function escapeHtml(str) {
-        if (str == null) return '';
-        const div = document.createElement('div');
-        div.appendChild(document.createTextNode(String(str)));
-        return div.innerHTML;
-    }
+    // escapeHtml is provided globally by main.js (window.escapeHtml)
 
     function addChip(name) {
         name = name.trim();


### PR DESCRIPTION
## Summary
- **N+1 queries fixed** — profile and public profile pages were firing one extra `Recipe.query` per comment and per rating in a Python loop. Replaced both with single `JOIN` queries via `db.session.query(Recipe, X)`. Tuple indexing (`item[0]`, `item[1]`) is identical to the old list indexing so templates required no changes.
- **`/users` search broken** — `users()` route had `q = ''` hardcoded, so the search bar on the Users page never filtered results. Now reads `q` from `request.args` and passes it to the template.
- **`badge-ai` CSS missing** — the AI badge class is used in `_recipe_card.html`, `_my_meal_card.html`, `community/feed.html`, and `detail.html` but had no CSS rule. Added a styled gradient pill with light-mode override.
- **Dead `showErrorToast` removed** — `main.js` had two definitions; the first (old Bootstrap alert impl) was overwritten by the second at runtime. Removed the dead one.
- **`escapeHtml` deduplicated** — local copies in `pantry.js` and `discover.js` removed; both now use `window.escapeHtml` from `main.js`.

## Test plan
- [x] 27/27 unit tests passing (`venv/bin/python -m pytest tests/unit/ -v`)
- [x] Python syntax clean (`python3 -m py_compile` on all modified routes)
- [x] JS syntax clean (`node --check` on all modified JS files)
- [x] Profile page query verified in app context — tuple indexing returns correct Recipe and Comment/Rating objects
- [x] All Flask routes load correctly (35 routes registered)
