### PR TITLE
Restore Discover + Pantry AI state on browser back

### DIFF
--- a/app/static/js/discover.js
+++ b/app/static/js/discover.js
@@ -28,6 +28,62 @@
     let currentCategory = initialCategory;
     let currentSort = 'newest';
 
+    /* ── Back-button state restoration ──
+     * Without this, clicking Load More → opening a recipe → hitting browser
+     * back drops you on page 1 again, losing your scroll position and the
+     * appended cards. We save the rendered HTML + filter state + scroll
+     * position to sessionStorage on pagehide, then restore on the next page
+     * load if the URL filters still match. 5-minute TTL so results don't
+     * silently get stale across long absences.
+     */
+    const DISCOVER_CACHE_KEY = 'pt-discover-results';
+    const DISCOVER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+    function currentFilterKey() {
+        return JSON.stringify({
+            q: currentQuery,
+            category: currentCategory,
+            sort: currentSort,
+        });
+    }
+
+    function saveDiscoverCache() {
+        // Nothing rendered yet (e.g. user navigated away during a fetch) — skip.
+        if (!resultsContainer.querySelector('.pt-card')) return;
+        try {
+            sessionStorage.setItem(DISCOVER_CACHE_KEY, JSON.stringify({
+                filterKey: currentFilterKey(),
+                html: resultsContainer.innerHTML,
+                currentPage: currentPage,
+                hasNext: !!document.getElementById('load-more-btn'),
+                resultCount: resultCount ? resultCount.textContent : '',
+                scrollY: window.scrollY,
+                ts: Date.now(),
+            }));
+        } catch (_) { /* quota or disabled */ }
+    }
+
+    function loadDiscoverCache() {
+        try {
+            const raw = sessionStorage.getItem(DISCOVER_CACHE_KEY);
+            if (!raw) return null;
+            const state = JSON.parse(raw);
+            if (!state || Date.now() - (state.ts || 0) > DISCOVER_CACHE_TTL_MS) {
+                sessionStorage.removeItem(DISCOVER_CACHE_KEY);
+                return null;
+            }
+            // Filters changed since cache was saved — drop and refetch fresh.
+            if (state.filterKey !== currentFilterKey()) {
+                sessionStorage.removeItem(DISCOVER_CACHE_KEY);
+                return null;
+            }
+            return state;
+        } catch (_) { return null; }
+    }
+
+    if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+    window.addEventListener('pagehide', saveDiscoverCache);
+
     /* ── Tag pills ── */
 
     function setActiveTag(activePill) {
@@ -251,20 +307,55 @@
         fetchRecipes(false);
     });
 
+    /* ── Restore cached results (back-button) BEFORE deciding to fetch ──
+     * If the user just came back from a recipe detail page and we have a
+     * matching cache, swap the rendered HTML in directly and skip the fetch.
+     * Returns true if the restore happened so the caller can skip refetching.
+     */
+    function tryRestoreFromCache() {
+        const state = loadDiscoverCache();
+        if (!state) return false;
+
+        resultsContainer.innerHTML = state.html;
+        currentPage = state.currentPage || 1;
+        if (resultCount && state.resultCount) {
+            resultCount.textContent = state.resultCount;
+        }
+        if (loadMoreWrap) {
+            loadMoreWrap.innerHTML = state.hasNext
+                ? '<button id="load-more-btn" class="btn btn-outline-light"><i class="bi bi-arrow-down-circle me-1"></i> Load More</button>'
+                : '';
+            bindLoadMore();
+        }
+        // Sync the UI controls (search box, tag pills) with the restored filter state.
+        if (searchInput) searchInput.value = currentQuery;
+        if (sortSelect)  sortSelect.value  = currentSort;
+        tagPills.forEach(t => {
+            const isMatch = (t.dataset.category || '').toLowerCase() === currentCategory;
+            t.classList.toggle('active', isMatch);
+            t.setAttribute('aria-pressed', String(isMatch));
+        });
+        // Jump to saved scroll position after the browser lays out the restored HTML.
+        requestAnimationFrame(() => window.scrollTo(0, state.scrollY || 0));
+        return true;
+    }
+
     /* ── Initial sync: apply ?category and ?q from URL on page load ── */
-    if (initialCategory || initialQuery) {
-        if (searchInput && initialQuery) {
-            searchInput.value = initialQuery;
+    if (!tryRestoreFromCache()) {
+        if (initialCategory || initialQuery) {
+            if (searchInput && initialQuery) {
+                searchInput.value = initialQuery;
+            }
+            if (initialCategory) {
+                tagPills.forEach(t => {
+                    const isMatch = t.dataset.category.toLowerCase() === initialCategory;
+                    t.classList.toggle('active', isMatch);
+                    t.setAttribute('aria-pressed', String(isMatch));
+                });
+            }
+            // Re-fetch from page 1 with the URL-derived filters applied.
+            currentPage = 1;
+            fetchRecipes(false);
         }
-        if (initialCategory) {
-            tagPills.forEach(t => {
-                const isMatch = t.dataset.category.toLowerCase() === initialCategory;
-                t.classList.toggle('active', isMatch);
-                t.setAttribute('aria-pressed', String(isMatch));
-            });
-        }
-        // Re-fetch from page 1 with the URL-derived filters applied.
-        currentPage = 1;
-        fetchRecipes(false);
     }
 })();

--- a/app/static/js/pantry.js
+++ b/app/static/js/pantry.js
@@ -11,6 +11,45 @@
     let lastMatches = [];
     let lastAiSuggestions = [];
 
+    /* ── Back-button state restoration ──
+     * Browser back from a recipe detail page would drop you on an empty pantry
+     * because the suggest results live only in JS memory. We persist the last
+     * results + scroll position to sessionStorage on pagehide, then restore on
+     * the next page load. sessionStorage is per-tab so this never leaks across
+     * sessions, and a 5-minute TTL keeps stale results from sticking around.
+     */
+    const CACHE_KEY = 'pt-pantry-results';
+    const CACHE_TTL_MS = 5 * 60 * 1000;
+
+    function savePantryCache() {
+        if (lastMatches.length === 0 && lastAiSuggestions.length === 0) return;
+        try {
+            sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+                matches: lastMatches,
+                ai_suggestions: lastAiSuggestions,
+                scrollY: window.scrollY,
+                ts: Date.now(),
+            }));
+        } catch (_) { /* quota or disabled — fall back to no-cache */ }
+    }
+
+    function loadPantryCache() {
+        try {
+            const raw = sessionStorage.getItem(CACHE_KEY);
+            if (!raw) return null;
+            const state = JSON.parse(raw);
+            if (!state || Date.now() - (state.ts || 0) > CACHE_TTL_MS) {
+                sessionStorage.removeItem(CACHE_KEY);
+                return null;
+            }
+            return state;
+        } catch (_) { return null; }
+    }
+
+    // Stop the browser from racing us on scroll restoration so we control it.
+    if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+    window.addEventListener('pagehide', savePantryCache);
+
     function getIngredients() {
         return Array.from(chipsContainer.querySelectorAll('.pantry-chip'))
             .map(c => c.dataset.name);
@@ -373,4 +412,18 @@
     document.getElementById('generateAiBtn').addEventListener('click', function () {
         doSuggest(true);
     });
+
+    /* Restore previously-cached results on page load (e.g. when the user clicked
+     * a result, viewed the recipe, then hit browser back). Runs after renderResults
+     * + all button handlers are defined so the restored DOM is fully interactive. */
+    (function restorePantryOnLoad() {
+        const state = loadPantryCache();
+        if (!state) return;
+        lastMatches = state.matches || [];
+        lastAiSuggestions = state.ai_suggestions || [];
+        if (lastMatches.length === 0 && lastAiSuggestions.length === 0) return;
+        renderResults(lastMatches, lastAiSuggestions);
+        // Wait for layout to settle before jumping to saved scroll position.
+        requestAnimationFrame(() => window.scrollTo(0, state.scrollY || 0));
+    })();
 })();


### PR DESCRIPTION
## Summary
Fixes a UX papercut where clicking into a recipe and hitting browser back would
drop the user back on a blank/page-1 state instead of where they left off.

## Problem
- **Discover**: Load More appends cards without pushing history state. Click a
  recipe → back → lands on page 1, lost the appended cards and scroll position.
- **Pantry AI**: results live entirely in JS memory (`lastMatches`,
  `lastAiSuggestions`). Click a recipe → back → results are gone, page is empty.

Both feel broken to the user even though the code is technically doing what it
was told.

## Fix
Cache rendered state to `sessionStorage` on `pagehide`, restore on next page
load. sessionStorage is per-tab so it never leaks across sessions; a 5-minute
TTL means stale results don't silently stick around.

### `app/static/js/pantry.js`
- New `savePantryCache()` / `loadPantryCache()` helpers.
- `pagehide` listener saves `{matches, ai_suggestions, scrollY, ts}`.
- New `restorePantryOnLoad` IIFE at end re-calls `renderResults()` and
  `scrollTo()` if cache is fresh.
- `history.scrollRestoration = 'manual'` so we control the scroll jump.

### `app/static/js/discover.js`
- New `currentFilterKey()` derives a JSON key from `q/category/sort` so caches
  for different filter combos don't collide.
- `saveDiscoverCache()` writes `{filterKey, html, currentPage, hasNext,
  resultCount, scrollY, ts}`.
- `loadDiscoverCache()` returns the cache only if TTL is fresh AND the saved
  filterKey matches the current URL filters (otherwise drops it).
- New `tryRestoreFromCache()` swaps the cached HTML directly into the results
  container, syncs the search box / sort / tag pills, re-binds Load More so
  pagination continues from the restored page, and scrolls to the saved Y.
- Restore runs BEFORE the existing URL-filter init block, short-circuiting the
  fetch when a cache hit happens.

## Edge cases handled
- Empty/null results don't write a cache (no stale "nothing" state).
- Filter change since save → cache dropped, normal fetch path takes over.
- sessionStorage quota or disabled → swallowed gracefully via try/catch.
- 5 minute TTL prevents stale results from sticking around indefinitely.
- Reveal animation skipped on restored cards (they're already "revealed" — no
  re-animation feels weird on back nav).

## What this doesn't do
- No in-page "Back" button — browser back is the right primitive, this just
  makes it work properly. Adding a second back button next to the browser's
  would be redundant.
- No backend changes. Pure client-side state restoration.

## Testing
1. Go to `/discover`, click Load More once or twice, scroll mid-page, click a
   recipe → browser back → you land exactly where you were, Load More still
   ready to fetch the next page.
2. Go to `/pantry`, add ingredients, click Find Matches, click into a result
   → browser back → results still showing, scroll restored.
3. Same flow but with Generate with AI → AI cards survive back-navigation.
4. Change a filter on `/discover` and verify the restore doesn't fire (cache
   filterKey no longer matches, so it gets dropped).